### PR TITLE
Fix Docker script permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,19 +62,19 @@ ENV LANG=zh_CN.UTF-8 \
 #      用 e.data 直发成品字符串（详见 woc-www-patch.sh / woc-ime.pl）。
 # 注意：实际加载的是 webpack 产物 dist/main.bundle.js（app/ui.js 是未打包源码、运行时不加载），故必须改 bundle。
 COPY woc-www-patch.sh woc-ime.pl /woc/
-RUN chmod +x /woc/woc-www-patch.sh && /woc/woc-www-patch.sh
+RUN chmod 755 /woc/woc-www-patch.sh && chmod 644 /woc/woc-ime.pl && /woc/woc-www-patch.sh
 
 # 微信下载/解压控制脚本（运行时由面板经 docker exec 触发，状态写入数据卷 /config/.woc-state）
 COPY wechat-ctl.sh /woc/wechat-ctl.sh
-RUN chmod +x /woc/wechat-ctl.sh
+RUN chmod 755 /woc/wechat-ctl.sh
 
 # openbox 会话启动时执行此脚本：等待微信就绪 + 常驻拉起微信 + 最小化自动复原看守
 COPY autostart /defaults/autostart
-RUN chmod +x /defaults/autostart
+RUN chmod 755 /defaults/autostart
 
 # 启动钩子：每次启动用镜像内最新 autostart 覆盖数据卷旧副本（否则旧实例升级后用不上新逻辑）
 COPY woc-update-autostart /custom-cont-init.d/01-woc-autostart
-RUN chmod +x /custom-cont-init.d/01-woc-autostart
+RUN chmod 755 /custom-cont-init.d/01-woc-autostart
 
 # 3000 = HTTP web 客户端, 3001 = HTTPS
 EXPOSE 3000 3001


### PR DESCRIPTION
## 改动内容

将 Docker 镜像内脚本的权限改为显式设置，而不是依赖源码文件权限再执行 `chmod +x`。

本次设置如下：

- `/woc/woc-www-patch.sh`：`755`
- `/woc/woc-ime.pl`：`644`
- `/woc/wechat-ctl.sh`：`755`
- `/defaults/autostart`：`755`
- `/custom-cont-init.d/01-woc-autostart`：`755`

## 修改原因

`COPY` 会把构建上下文里的文件权限带进镜像。如果仓库是在比较严格的 `umask` 下检出或复制的，例如 `077`，脚本文件可能会以 `600` 进入镜像。

这时再执行 `chmod +x`，最终权限会变成 `711`：文件“可执行”，但对非 owner 用户不可读。Shell 脚本执行时解释器需要读取脚本内容，所以运行时用户 `abc` 执行这些脚本会失败。

实际表现之一是：

```text
/woc/wechat-ctl.sh: Permission denied
```

随后面板读取不到安装状态，只能回退成“未安装/idle”，用户侧看起来就是下载安装进度条出现后消失。

改成显式 `755/644` 后，镜像构建结果不再受构建机 `umask` 或本地文件权限影响。

## 验证方式

已构建实例镜像并验证运行时用户可以执行控制脚本：

```bash
docker build -t ghcr.io/mkblbj/wechat-on-cloud:pr-script-permissions ./docker

docker run --rm --entrypoint sh ghcr.io/mkblbj/wechat-on-cloud:pr-script-permissions -lc '
  command -v xclip
  command -v xdotool
  stat -c "%a %U:%G %n" /woc/woc-www-patch.sh /woc/woc-ime.pl /woc/wechat-ctl.sh /defaults/autostart /custom-cont-init.d/01-woc-autostart
  su abc -s /bin/sh -c /woc/wechat-ctl.sh\ status
'
```

验证结果：

```text
755 root:root /woc/woc-www-patch.sh
644 root:root /woc/woc-ime.pl
755 root:root /woc/wechat-ctl.sh
755 root:root /defaults/autostart
755 root:root /custom-cont-init.d/01-woc-autostart
```

并且 `abc` 用户执行 `/woc/wechat-ctl.sh status` 成功。
