### PR TITLE
优化移动端软键盘弹出时的桌面窗口避让

### DIFF
--- a/panel/web/src/pages/Desktop.tsx
+++ b/panel/web/src/pages/Desktop.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { api } from '../api';
 import { useUI } from '../ui';
@@ -53,6 +53,9 @@ export default function InstanceView({ onOpenMenu }: { onOpenMenu: () => void })
   const dragDepth = useRef(0);
   const lastBeat = useRef(0);
   const lastImeError = useRef(0);
+  const viewportBaseHeight = useRef(0);
+  const viewportWidth = useRef(0);
+  const [keyboardInset, setKeyboardInset] = useState(0);
 
   const inst = instances.find((i) => i.id === id);
   // 进入实例时，共享列表可能尚未同步（管理页新建/安装后），先按"探测中"显示加载态，
@@ -61,6 +64,7 @@ export default function InstanceView({ onOpenMenu }: { onOpenMenu: () => void })
   const offline = inst ? inst.runtime !== 'running' : false;
   const installed = !!inst && inst.wechat.installed && inst.wechat.phase !== 'downloading';
   const showVnc = !!inst && !offline && installed;
+  const pageStyle = keyboardInset > 0 ? ({ '--woc-keyboard-inset': `${keyboardInset}px` } as CSSProperties) : undefined;
 
   // 切换实例时重置内嵌态
   useEffect(() => {
@@ -185,6 +189,66 @@ export default function InstanceView({ onOpenMenu }: { onOpenMenu: () => void })
       }
     };
   }, [showVnc, id, frameLoaded]);
+
+  // 移动端软键盘通常覆盖 visual viewport，而不是重新布局页面；这里计算底部被键盘
+  // 占掉的高度，并让 VNC 画面主动缩到键盘上方，避免微信输入框被键盘盖住。
+  useEffect(() => {
+    const vv = window.visualViewport;
+    const updateKeyboardInset = () => {
+      const mobileLike = window.matchMedia('(max-width: 767px), (pointer: coarse)').matches;
+      if (!mobileLike || !vv) {
+        viewportBaseHeight.current = 0;
+        viewportWidth.current = 0;
+        setKeyboardInset(0);
+        return;
+      }
+
+      const width = Math.round(vv.width || window.innerWidth);
+      const layoutHeight = Math.max(
+        document.documentElement.clientHeight,
+        window.innerHeight,
+        vv.height + vv.offsetTop,
+      );
+      if (!viewportBaseHeight.current || Math.abs(width - viewportWidth.current) > 40) {
+        viewportBaseHeight.current = layoutHeight;
+        viewportWidth.current = width;
+      }
+
+      viewportBaseHeight.current = Math.max(viewportBaseHeight.current, layoutHeight);
+      const obscured = Math.round(viewportBaseHeight.current - vv.height - vv.offsetTop);
+      const nextInset = obscured >= 120 ? obscured : 0;
+      setKeyboardInset((prev) => (prev === nextInset ? prev : nextInset));
+    };
+
+    const resetKeyboardBase = () => {
+      viewportBaseHeight.current = 0;
+      window.setTimeout(updateKeyboardInset, 80);
+    };
+
+    updateKeyboardInset();
+    vv?.addEventListener('resize', updateKeyboardInset);
+    vv?.addEventListener('scroll', updateKeyboardInset);
+    window.addEventListener('resize', updateKeyboardInset);
+    window.addEventListener('orientationchange', resetKeyboardBase);
+    return () => {
+      vv?.removeEventListener('resize', updateKeyboardInset);
+      vv?.removeEventListener('scroll', updateKeyboardInset);
+      window.removeEventListener('resize', updateKeyboardInset);
+      window.removeEventListener('orientationchange', resetKeyboardBase);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!showVnc || !frameLoaded) return;
+    const t = window.setTimeout(() => {
+      try {
+        frameRef.current?.contentWindow?.dispatchEvent(new Event('resize'));
+      } catch {
+        /* ignore */
+      }
+    }, 80);
+    return () => window.clearTimeout(t);
+  }, [keyboardInset, showVnc, frameLoaded]);
 
   if (!id) {
     nav('/', { replace: true });
@@ -447,7 +511,7 @@ export default function InstanceView({ onOpenMenu }: { onOpenMenu: () => void })
   const title = inst?.name || '微信实例';
 
   return (
-    <div className="ws-page">
+    <div className={'ws-page' + (keyboardInset > 0 ? ' soft-keyboard-open' : '')} style={pageStyle}>
       <header className="ws-head">
         <button className="ws-menu" onClick={onOpenMenu} aria-label="菜单">
           {MenuIcon}

--- a/panel/web/src/styles.css
+++ b/panel/web/src/styles.css
@@ -1641,6 +1641,12 @@ button {
   .ws-action {
     padding: 7px 12px;
   }
+  .ws-page.soft-keyboard-open {
+    height: calc(100% - var(--woc-keyboard-inset, 0px));
+  }
+  .ws-page.soft-keyboard-open .iv-files {
+    max-height: calc(100% - 28px);
+  }
 }
 
 /* 宽屏：工作区内容容器更宽（实例网格多列） */


### PR DESCRIPTION
## 背景

在移动端访问实例桌面时，项目本身已经会收起侧边栏，让微信 / VNC 窗口尽量全屏显示。

但当用户点击微信输入框并呼出系统软键盘时，移动端浏览器通常不会真正重新布局整个页面，而是让软键盘覆盖页面底部区域。

结果是：

- 微信窗口下半部分会被软键盘遮挡
- 微信输入框附近区域不可见
- 用户输入时看不到当前输入位置或聊天窗口底部内容
- 尤其在手机竖屏场景下体验比较明显

## 改动内容

这次改动在实例桌面页增加了移动端软键盘避让逻辑。

主要包括：

1. 监听 `window.visualViewport`

   通过 `visualViewport.resize` / `visualViewport.scroll` 监听页面可视区域变化，计算软键盘占用的底部高度。

2. 只在移动端场景生效

   当前逻辑只在移动端 / 粗指针设备上启用：

   ```ts
   window.matchMedia('(max-width: 767px), (pointer: coarse)')
   ```

   桌面端不会受到影响。

3. 动态缩小实例页面高度

   当检测到软键盘弹出时，会给实例页面设置：

   ```css
   --woc-keyboard-inset
   ```

   并让实例页面高度减去软键盘占用高度，使 VNC / 微信窗口主动缩到键盘上方。

4. 键盘收起后自动恢复

   当 `visualViewport` 恢复正常高度，避让高度会重置为 `0`，页面恢复原本全屏布局。

5. 通知 noVNC 重新适配

   在键盘高度变化后，会向 iframe 内部派发一次 `resize` 事件，让 noVNC 感知外层容器尺寸变化并重新适配画面。

## 为什么使用 visualViewport

移动端软键盘行为在不同浏览器中不完全一致。

很多情况下，软键盘弹出不会可靠改变 `window.innerHeight`，但会改变 `window.visualViewport.height`。

因此这里优先使用 `visualViewport` 来判断真实可视区域，避免仅依赖传统 viewport 高度导致判断不准。

## 已验证

已在移动端实际部署场景中验证：

- 点击微信输入框后，软键盘弹出时 VNC / 微信窗口会缩到键盘上方
- 微信输入框不再被键盘遮挡
- 键盘收起后窗口高度可以恢复
- 中文 IME 输入修复仍然正常
- 桌面端布局不受影响

## 兼容性说明

如果浏览器不支持 `window.visualViewport`，该逻辑会自动跳过，保持原有布局行为。

当前避让逻辑只影响移动端 / 触屏设备，不改变桌面端的 VNC 显示方式。

这个改动没有修改 KasmVNC / noVNC 内部逻辑，只是在外层 panel 页面根据移动端软键盘高度调整 iframe 容器尺寸，因此风险相对较小。
