### PR TITLE
fix: pass /dev/dri through to instance container when WOC_ENABLE_GPU=1

### DIFF
--- a/panel/server/src/docker.ts
+++ b/panel/server/src/docker.ts
@@ -1,5 +1,5 @@
 import { hostname } from 'node:os';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { appendInstanceLog, deleteInstanceLog, appendPanelLog, readInstanceLog, readPanelLog, filterSince } from './logs.js';
 import http from 'node:http';
 import zlib from 'node:zlib';
@@ -15,7 +15,8 @@ const SHM_SIZE = 1024 * 1024 * 1024; // 1gb
 // 默认关闭 KasmVNC 的 GPU 硬件编码（baseimage 检测到 /dev/dri/renderD* 时会给 Xvnc 加 -hw3d）：
 // 在 WSL2 / 虚拟 GPU 环境下该路径会导致 Xvnc 内存持续膨胀（实测反馈 21h 涨到 ~9GB）。
 // 我们已设 LIBGL_ALWAYS_SOFTWARE=1 走软件渲染，hw3d 对微信这类静态界面收益甚微。
-// 真实可用 GPU 想启用硬件编码：面板侧设 WOC_ENABLE_GPU=1。
+// 真实可用 GPU 想启用硬件编码：面板侧设 WOC_ENABLE_GPU=1，并让面板可见宿主 /dev/dri
+// （如同摄像头，把宿主 /dev 挂到 /host-dev，或设 WOC_DRI_DEVICES 显式指定）。
 const ENABLE_GPU = process.env.WOC_ENABLE_GPU === '1';
 
 // 可选：给每个实例容器设内存上限（GiB），作为 Xvnc 等异常增长时的兜底，避免拖垮宿主。
@@ -114,6 +115,47 @@ function videoDevices(): string[] {
   return [];
 }
 
+// GPU 直通：把宿主 /dev/dri 渲染节点映射进实例容器，仅 WOC_ENABLE_GPU=1 时生效。
+// 来源优先级：
+//   1) WOC_DRI_DEVICES 显式指定（逗号分隔，如 /dev/dri/renderD128,/dev/dri/card0）；
+//   2) 自动探测：扫描面板可见的 /host-dev/dri 或 /dev/dri 中的 renderD*/card*。
+// 一个都找不到则返回空：硬件编码不可用，但实例照常创建（优雅降级）。
+function driDevices(): string[] {
+  const explicit = (process.env.WOC_DRI_DEVICES || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (explicit.length) return explicit;
+  for (const dir of ['/host-dev/dri', '/dev/dri']) {
+    try {
+      if (!existsSync(dir)) continue;
+      const dris = readdirSync(dir)
+        .filter((n) => /^(renderD\d+|card\d+)$/.test(n))
+        .map((n) => `/dev/dri/${n}`); // 宿主侧设备路径
+      if (dris.length) return dris;
+    } catch {
+      /* 无权限/不可读，忽略 */
+    }
+  }
+  return [];
+}
+
+// 读取这些 DRI 设备文件的属主数字 GID。宿主上 /dev/dri/renderD* 常归属一个「动态分配」的
+// render 组（其 GID 因发行版而异），与镜像内 render 组的 GID 未必一致；仅靠组名加 GroupAdd
+// 时，容器内 abc 用户可能仍打不开渲染节点（permission denied）。把宿主侧真实数字 GID 一并
+// 加进 GroupAdd，才能保证可访问。读取失败/无权限则跳过（退回仅组名，优雅降级）。
+function driDeviceGids(devices: string[]): string[] {
+  const gids = new Set<string>();
+  for (const dev of devices) {
+    try {
+      gids.add(String(statSync(dev).gid));
+    } catch {
+      /* 设备不可 stat（面板未挂 /host-dev 等），忽略 */
+    }
+  }
+  return Array.from(gids);
+}
+
 function envList(inst: Instance): string[] {
   const env = [
     `PUID=${PUID}`,
@@ -174,6 +216,7 @@ export async function runInstance(inst: Instance): Promise<void> {
   }
   // 摄像头设备（探测不到则为空数组 → 仅摄像头不可用，音频/麦克风照常）
   const vids = videoDevices();
+  const dris = ENABLE_GPU ? driDevices() : [];
   const hostConfig: Docker.HostConfig = {
     Binds: [`${inst.volumeName}:/config`],
     NetworkMode: net || undefined,
@@ -189,6 +232,17 @@ export async function runInstance(inst: Instance): Promise<void> {
     hostConfig.Devices = vids.map((d) => ({ PathOnHost: d, PathInContainer: d, CgroupPermissions: 'rwm' }));
     hostConfig.GroupAdd = ['video']; // 让容器内 abc 用户能访问 /dev/videoN
     console.log(`[docker] 实例 ${inst.id} 挂载摄像头设备: ${vids.join(', ')}`);
+  }
+  if (dris.length) {
+    hostConfig.Devices = [
+      ...(hostConfig.Devices || []),
+      ...dris.map((d) => ({ PathOnHost: d, PathInContainer: d, CgroupPermissions: 'rwm' })),
+    ];
+    // 组名 render/video + 宿主侧真实数字 GID（应对 render 组 GID 在宿主与镜像间不一致的常见情况）。
+    hostConfig.GroupAdd = Array.from(
+      new Set([...(hostConfig.GroupAdd || []), 'render', 'video', ...driDeviceGids(dris)]),
+    );
+    console.log(`[docker] 实例 ${inst.id} 挂载 GPU 渲染设备: ${dris.join(', ')}`);
   }
   // 伪装成真实有线网卡 MAC（厂商 OUI），替代容器默认的本地管理位 MAC。
   const mac = realisticMac(inst.id);


### PR DESCRIPTION
## Summary

设置 `WOC_ENABLE_GPU=1` 时，把宿主的 `/dev/dri` 渲染节点直通进实例容器，让 KasmVNC baseimage 真正检测到 `/dev/dri/renderD*` 并启用 `-hw3d` 硬件编码。

Pass the host `/dev/dri` render/card devices through to the instance container when `WOC_ENABLE_GPU=1`, mirroring the existing camera (`/dev/video*`) passthrough.

## Why this matters

复现 #36：面板设了 `WOC_ENABLE_GPU=1` 却无任何效果，硬件编码没开起来。

根因：`ENABLE_GPU` 目前只决定是否给容器下发 `DISABLE_DRI=1`（设了就不下发，让 baseimage 自动探测 `/dev/dri/renderD*` 加 `-hw3d`）。但 `panel/server/src/docker.ts` 的 `runInstance()` 从未把宿主 `/dev/dri` 设备直通进容器的 `HostConfig.Devices`。容器内没有 DRI 设备节点 → baseimage 自动探测找不到 → `-hw3d` 永远不启用 → 该开关形同虚设，正好对应 reporter 反馈的现象。

Root cause: `WOC_ENABLE_GPU` only controls whether `DISABLE_DRI=1` is set, but `runInstance()` never actually maps the host `/dev/dri` nodes into the container. Without a DRI device inside, the baseimage's auto-detection finds nothing and `-hw3d` is never enabled, so the flag is inert.

## Changes

`panel/server/src/docker.ts`：

- 新增 `driDevices()` 辅助函数，完全照搬现有 `videoDevices()` 摄像头直通模式：优先读 `WOC_DRI_DEVICES`（逗号分隔显式指定，对齐 `WOC_VIDEO_DEVICES`），否则扫描 `/host-dev/dri` → `/dev/dri` 中的 `renderD*`/`card*`；找不到返回空，优雅降级。
- `runInstance()` 中加 `const dris = ENABLE_GPU ? driDevices() : []`，并在已有摄像头设备块之后追加 DRI 直通块：把 DRI 设备**追加**进 `hostConfig.Devices`（不覆盖摄像头设备），合并去重 `GroupAdd`，并按摄像头同样方式打日志。
- 新增 `driDeviceGids()`：把宿主侧 `/dev/dri/*` 的真实数字 GID 一并加进 `GroupAdd`。宿主上 render 组的 GID 因发行版而异、未必与镜像内一致，仅靠组名可能仍权限不足；加上数字 GID 才能保证容器内 `abc` 用户打得开渲染节点。
- 更新 `WOC_ENABLE_GPU` 注释，说明真实直通还需面板能看到宿主 `/dev/dri`（像摄像头那样把宿主 `/dev` 挂到 `/host-dev`，或设 `WOC_DRI_DEVICES`）。

所有逻辑完全 gate 在 `ENABLE_GPU` 之下：默认（GPU 关）路径与现状逐字节一致，无任何回归。

## Testing

本仓库无自动化测试框架（`panel/server` 无测试脚本/框架），Docker 设备直通也无法在不引入项目未使用的 dockerode mock 的前提下做单测，故为人工/结构化验证：

- `npx tsc --noEmit` 通过（无类型错误），改动按 `Docker.HostConfig.Devices` 类型正确构造。
- 结构核对，照搬已验证的摄像头直通路径：
  - **GPU 关（默认，`WOC_ENABLE_GPU` 未设）**：`dris` 恒为 `[]`，`HostConfig` 与现状逐字节一致（无回归）。
  - **GPU 开，宿主有 `/dev/dri/renderD128`**：`runInstance()` 把它加进 `HostConfig.Devices`，加上 `render`/`video` 组及其数字 GID，且不下发 `DISABLE_DRI=1`，baseimage 即可加 `-hw3d`。
  - **GPU 开 + `WOC_DRI_DEVICES` 显式指定**：尊重显式列表、跳过自动探测（与 `WOC_VIDEO_DEVICES` 行为一致）。
  - **GPU 开但无 DRI 节点**（未挂 `/host-dev` / 无头宿主）：不加设备、不抛错、实例照常创建（优雅降级，对齐摄像头路径）。
  - **GPU 开且同时有摄像头**：`/dev/video*` 与 `/dev/dri/*` 同时出现在 `HostConfig.Devices`，互不覆盖。

Fixes #36
