### PR TITLE
fix: 415 on no-body heartbeat requests (missing Content-Type)

### DIFF
--- a/panel/server/src/index.ts
+++ b/panel/server/src/index.ts
@@ -117,6 +117,9 @@ app.addHook('onRequest', async (req, reply) => {
 await app.register(cookie);
 // 文件上传走原始二进制（前端以 application/octet-stream 直传 File）
 app.addContentTypeParser('application/octet-stream', { parseAs: 'buffer' }, (_req, body, done) => done(null, body));
+// Heartbeat and other no-body POST routes send no Content-Type; fall through to this wildcard
+// instead of being rejected with 415. Fastify's exact-match parsers above take priority.
+app.addContentTypeParser('*', { parseAs: 'buffer' }, (_req, _body, done) => done(null, null));
 
 // ---------- 鉴权辅助 ----------
 function currentUser(req: FastifyRequest): User | null {


### PR DESCRIPTION
## Problem

`POST /api/instances/:id/control/beat` is a keep-alive heartbeat with no
request body. The frontend sends it without a `Content-Type` header.

Fastify's content-type parser is whitelist-based: any request whose
`Content-Type` does not match a registered parser — including requests
with no `Content-Type` at all — is rejected with **415 Unsupported Media
Type**. The panel registers parsers for `application/json` (built-in) and
`application/octet-stream`, but has no handler for the missing-header
case, so every heartbeat call from the frontend fails silently with 415.

## Fix

Register a `'*'` wildcard content-type parser as a catch-all. Fastify
resolves parsers by exact match first, so the two existing parsers retain
their priority; the wildcard only fires when nothing else matches. The
beat handler does not use the request body, so returning `null` is
correct.

```ts
// Heartbeat and other no-body POST routes send no Content-Type; fall through to this wildcard
// instead of being rejected with 415. Fastify's exact-match parsers above take priority.
app.addContentTypeParser('*', { parseAs: 'buffer' }, (_req, _body, done) => done(null, null));
```

## Verification

- `POST /control/beat` without `Content-Type` → **403** (reaches auth
  check, no longer rejected at the content-type layer)
- Existing `application/json` and `application/octet-stream` routes →
  unaffected, continue to return **200**