### PR TITLE
fix: retire stale PWA caches

### DIFF
--- a/panel/server/src/index.ts
+++ b/panel/server/src/index.ts
@@ -5,6 +5,7 @@ import httpProxy from 'http-proxy';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { IncomingMessage } from 'node:http';
+import type { ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
 import {
   initStore,
@@ -1264,13 +1265,33 @@ app.all('/desktop/:id', desktopHandler);
 app.all('/desktop/:id/*', desktopHandler);
 
 // ---------- 静态 SPA + 前端路由回退 ----------
-await app.register(fstatic, { root: STATIC_DIR, wildcard: false, index: ['index.html'] });
+function setStaticCacheHeaders(res: ServerResponse, pathName: string) {
+  if (pathName.endsWith('index.html') || pathName.endsWith('/sw.js') || pathName.endsWith('/manifest.webmanifest')) {
+    res.setHeader('Cache-Control', 'no-store, max-age=0');
+    return;
+  }
+  if (pathName.includes('/assets/')) {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  }
+}
+
+function sendSpaIndex(reply: FastifyReply) {
+  reply.header('Cache-Control', 'no-store, max-age=0');
+  return reply.sendFile('index.html');
+}
+
+await app.register(fstatic, {
+  root: STATIC_DIR,
+  wildcard: false,
+  index: ['index.html'],
+  setHeaders: setStaticCacheHeaders,
+});
 app.setNotFoundHandler((req, reply) => {
   const url = req.raw.url || '';
   if (url.startsWith('/api') || url.startsWith('/desktop')) {
     return reply.code(404).send({ error: 'not found' });
   }
-  return reply.sendFile('index.html');
+  return sendSpaIndex(reply);
 });
 
 // ---------- 启动 + WebSocket 升级（同样校验会话） ----------

--- a/panel/web/public/sw.js
+++ b/panel/web/public/sw.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+    await self.registration.unregister();
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clients) client.navigate(client.url);
+  })());
+});

--- a/panel/web/src/main.tsx
+++ b/panel/web/src/main.tsx
@@ -4,17 +4,19 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './styles.css';
 
-// PWA 更新即时生效：vite-plugin-pwa 用 autoUpdate + skipWaiting + clientsClaim，新版本会立即接管，
-// 但当前页仍显示已加载的旧资源，需再刷一次才生效——这正是"改了却还看旧界面"的根源。这里监听 SW 接管，
-// 在"本来已有 SW 在控制"（即一次更新，而非首次安装）时自动重载一次，让更新一刷即生效。
+// The panel is a live remote desktop gateway; stale PWA caches can keep an old
+// login bundle alive after Cloudflare Access reauth. Retire any SW installed by
+// earlier releases and clear its Cache Storage entries.
 if ('serviceWorker' in navigator) {
-  const hadController = !!navigator.serviceWorker.controller;
-  let reloaded = false;
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (reloaded || !hadController) return;
-    reloaded = true;
-    window.location.reload();
-  });
+  navigator.serviceWorker.getRegistrations()
+    .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
+    .catch(() => {});
+}
+
+if ('caches' in window) {
+  caches.keys()
+    .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+    .catch(() => {});
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/panel/web/vite.config.ts
+++ b/panel/web/vite.config.ts
@@ -1,41 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { VitePWA } from 'vite-plugin-pwa';
 
 // 开发时把 /api 与 /desktop 代理到本地后端（npm run dev 时用）
 const BACKEND = process.env.BACKEND || 'http://localhost:8080';
 
 export default defineConfig({
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['favicon.svg', 'icon-180.png'],
-      manifest: {
-        name: '云微',
-        short_name: '云微',
-        description: '在浏览器访问 NAS 上的微信',
-        lang: 'zh-CN',
-        theme_color: '#07C160',
-        background_color: '#ffffff',
-        display: 'standalone',
-        start_url: '/',
-        icons: [
-          { src: 'icon-192.png', sizes: '192x192', type: 'image/png' },
-          { src: 'icon-512.png', sizes: '512x512', type: 'image/png' },
-          { src: 'icon-512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
-        ],
-      },
-      workbox: {
-        // 桌面反代与 API 不能被 SW 拦截
-        navigateFallbackDenylist: [/^\/desktop/, /^\/api/],
-        // 新版本立即接管 + 清理旧缓存，避免更新后仍跑旧代码（硬刷新绕不过 SW）
-        clientsClaim: true,
-        skipWaiting: true,
-        cleanupOutdatedCaches: true,
-      },
-    }),
-  ],
+  plugins: [react()],
   server: {
     proxy: {
       '/api': BACKEND,


### PR DESCRIPTION
Summary: stop generating the panel PWA service worker, unregister older service workers at startup, add a self-retiring /sw.js, and send no-store headers for HTML, sw.js, and the web manifest while preserving immutable caching for hashed assets. Why: stale PWA caches can keep old panel bundles alive after deploys, which is especially visible behind reverse proxies or identity proxies. This prevents old login/API code from surviving across updates. Verification: npm run build -- --emptyOutDir=false.