### PR TITLE
[codex] Prevent Chromium metrics cache from bloating volumes

### DIFF
--- a/docker/app-defs.sh
+++ b/docker/app-defs.sh
@@ -15,8 +15,10 @@ woc_app_def() {
       # --disable-background-networking：关掉 Chromium 后台 phone-home（GCM 推送 / 组件更新 / 变体下载），
       #   在受限网络（NAS / 被墙）下这些会反复失败刷屏 "gcm ConnectionHandler failed net error: -2"。
       #   只影响后台流量，不影响前台网页加载与真实网络错误提示。
+      # --disable-metrics* / --disable-crash-reporter / --disable-breakpad：避免无头/容器场景下 Chromium
+      #   把延迟指标与崩溃上报缓存长期写进持久化数据卷（曾见 DeferredBrowserMetrics 异常膨胀到数百 GiB）。
       APP_BIN=/usr/bin/chromium
-      APP_LAUNCH="$APP_BIN --no-sandbox --no-first-run --no-default-browser-check --start-maximized --password-store=basic --disable-gpu --disable-background-networking --user-data-dir=/config/chromium"
+      APP_LAUNCH="$APP_BIN --no-sandbox --no-first-run --no-default-browser-check --start-maximized --password-store=basic --disable-gpu --disable-background-networking --disable-metrics --disable-metrics-reporting --disable-crash-reporter --disable-breakpad --user-data-dir=/config/chromium"
       APP_NAME=Chromium
       ;;
     custom)

--- a/docker/autostart
+++ b/docker/autostart
@@ -47,6 +47,14 @@ if [ "$APP_TYPE" = "custom" ] && [ -z "${APP_LAUNCH:-}" ]; then
     exit 0
 fi
 
+cleanup_chromium_metrics() {
+    [ "$APP_TYPE" = "chromium" ] || return 0
+    metrics_dir=/config/chromium/DeferredBrowserMetrics
+    [ -e "$metrics_dir" ] || return 0
+    echo "[autostart] 清理 Chromium 延迟指标缓存: ${metrics_dir}"
+    rm -rf "$metrics_dir" 2>/dev/null || true
+}
+
 # 1) 应用壁纸（若用户设置了自定义背景图）。
 # 关键：Xvnc 启动时是默认分辨率，浏览器连上后 KasmVNC 会 resize-remote 到浏览器尺寸。若只在启动时设一次，
 # 屏幕一变大，X 会把当时设的小尺寸 root pixmap【平铺】填满新屏（表现为壁纸被 2×2 平铺，见 issue 反馈）。
@@ -176,7 +184,9 @@ while true; do
     fi
     echo "[autostart] 启动 ${APP_NAME}: ${APP_LAUNCH}"
     # APP_LAUNCH 可带参数，按 word-split 执行（各应用参数均不含空格，见 app-defs.sh）
+    cleanup_chromium_metrics
     ${APP_LAUNCH}
+    cleanup_chromium_metrics
     echo "[autostart] ${APP_NAME} 已退出，2 秒后重启"
     sleep 2
 done


### PR DESCRIPTION
## What changed

This PR hardens Chromium app instances against persistent metrics cache growth:

- disables Chromium metrics/crash reporting flags for Chromium instances
- removes `/config/chromium/DeferredBrowserMetrics` before launch and after exit
- leaves the rest of the persisted Chromium profile untouched, including `Default/` and login/session state

## Why

Chromium instances persist their profile under `/config/chromium`. In a long-running container profile, `DeferredBrowserMetrics` can grow without bound and consume the host Docker volume. This was observed in the field with the directory growing to hundreds of GiB inside a `woc-data-*` volume.

## Validation

- `bash -n docker/autostart docker/app-defs.sh`
- `git diff --check`
