### PR TITLE
fix: correct and make socket proxy image configurable

### DIFF
--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -9,7 +9,7 @@
 services:
 
   docker-socket-proxy:
-    image: tecnativo/docker-socket-proxy:latest   # 生产环境建议固定到具体 digest，见 doc/安全加固.md
+    image: tecnativa/docker-socket-proxy:latest   # 生产环境建议固定到具体 digest，见 doc/安全加固.md
     container_name: woc-socket-proxy
     restart: unless-stopped
     volumes:

--- a/docker-compose.secure.yml
+++ b/docker-compose.secure.yml
@@ -9,7 +9,7 @@
 services:
 
   docker-socket-proxy:
-    image: tecnativa/docker-socket-proxy:latest   # 生产环境建议固定到具体 digest，见 doc/安全加固.md
+    image: ${WOC_SOCKET_PROXY_IMAGE:-tecnativa/docker-socket-proxy:latest}   # 生产环境建议固定到具体 digest，见 doc/安全加固.md
     container_name: woc-socket-proxy
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## What changed

- Correct the socket proxy image namespace from `tecnativo` to `tecnativa`.
- Allow deployments to override the image through `WOC_SOCKET_PROXY_IMAGE` while preserving the current `latest` default.

## Why

The secure Compose overlay currently references a misspelled Docker Hub namespace, so enabling the overlay cannot pull the intended image. An environment override also lets production deployments pin an immutable digest without editing the Compose file.

## Impact

The default secure-overlay workflow can pull the correct proxy image, while existing deployments retain the same default behavior.

## Validation

- Rebased onto the latest upstream `main`.
- `git diff --check` passes.
- The corrected image and digest override were exercised in a live NAS deployment through the secure overlay; container lifecycle operations worked through the proxy and denied Docker network API access.
