### PR TITLE
fix(security): keep panel credential files private

### DIFF
--- a/panel/server/src/sessions.ts
+++ b/panel/server/src/sessions.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from 'node:fs';
+import { chmodSync, readFileSync, writeFileSync, renameSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 interface Session {
@@ -36,13 +36,14 @@ function save() {
   saveTimer = setTimeout(() => {
     saveTimer = null;
     try {
-      mkdirSync(dirname(FILE), { recursive: true });
+      mkdirSync(dirname(FILE), { recursive: true, mode: 0o700 });
       const now = Date.now();
       const obj: Record<string, Session> = {};
       for (const [t, s] of sessions) if (s.expires > now) obj[t] = s;
       const tmp = `${FILE}.tmp`;
       writeFileSync(tmp, JSON.stringify(obj), { mode: 0o600 });
       renameSync(tmp, FILE);
+      chmodSync(FILE, 0o600);
     } catch {
       /* 写盘失败不致命：本进程内存里仍有会话 */
     }

--- a/panel/server/src/store.ts
+++ b/panel/server/src/store.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
+import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { randomBytes, randomUUID } from 'node:crypto';
 import bcrypt from 'bcryptjs';
@@ -77,10 +77,11 @@ const FILE = process.env.PANEL_DATA || '/data/panel/accounts.json';
 let data: Data = { users: [], instances: [] };
 
 function persist() {
-  mkdirSync(dirname(FILE), { recursive: true });
+  mkdirSync(dirname(FILE), { recursive: true, mode: 0o700 });
   const tmp = `${FILE}.tmp`;
-  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
   renameSync(tmp, FILE);
+  chmodSync(FILE, 0o600);
 }
 
 function makeUser(username: string, password: string, role: Role): User {


### PR DESCRIPTION
## What changed

- Create panel data directories with owner-only permissions when they do not already exist.
- Write account and session temporary files with mode `0600`.
- Re-apply mode `0600` after the atomic rename so existing files with broader permissions are repaired on the next save.

## Why

`accounts.json` contains password hashes and instance ownership data, while `sessions.json` contains active session tokens. The account store previously relied on the process umask, and an existing destination file could retain broader permissions across atomic replacements.

## Impact

Panel credential files remain readable and writable only by the container user without changing their format or persistence flow.

## Validation

- Rebased onto the latest upstream `main`.
- `git diff --check` passes.
- The persistence path was exercised in a live NAS deployment; the resulting `accounts.json` was verified as mode `0600` and the panel remained healthy.
