### PR TITLE
build: use lockfiles for panel image builds

### DIFF
--- a/panel/Dockerfile
+++ b/panel/Dockerfile
@@ -3,8 +3,8 @@
 # --- 1) 构建前端 ---
 FROM node:22-slim AS web
 WORKDIR /web
-COPY web/package.json ./
-RUN npm install
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
 COPY web/ ./
 RUN npm run build
 
@@ -12,8 +12,8 @@ RUN npm run build
 FROM node:22-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-COPY server/package.json ./
-RUN npm install
+COPY server/package.json server/package-lock.json ./
+RUN npm ci --omit=dev
 COPY server/ ./
 COPY --from=web /web/dist ./web-dist
 


### PR DESCRIPTION
## What changed

- Copy each panel workspace's `package-lock.json` into the Docker build before installing dependencies.
- Use `npm ci` for the web build stage.
- Use `npm ci --omit=dev` for the production server stage.

## Why

The panel image currently copies only `package.json` and runs `npm install`. That can resolve newer transitive dependency versions over time even when the repository's lockfiles have not changed, making image builds non-reproducible.

## Impact

Panel images now use the dependency graph committed to the repository. Production images continue to exclude server development dependencies.

## Validation

- Rebased onto the latest upstream `main`.
- `git diff --check` passes.
- Upstream has not changed the panel Dockerfile or either package/lockfile pair since the NAS-tested revision.
- A complete panel image build using these `npm ci` stages succeeded on the target NAS and the resulting panel passed its health check.
