### PR TITLE
fix(watchdog): preserve instances while VNC viewers are connected

### DIFF
--- a/panel/server/src/index.ts
+++ b/panel/server/src/index.ts
@@ -1318,6 +1318,30 @@ app.post('/api/admin/instances/:id/fonts/default', async (req, reply) => {
 // ---------- 反向代理到内网 KasmVNC（按实例注入 Basic auth，会话 + 权限把守） ----------
 // 单个 proxy 实例，target 与凭据逐请求指定：凭据暂存在 req 上，proxyReq 时注入。
 const proxy = httpProxy.createProxyServer({ changeOrigin: true, ws: true });
+// 控制权心跳只代表最近有键鼠操作，不能代表桌面是否仍在观看。Chrome 标签页进入后台后
+// 不再产生键鼠事件，但 VNC WebSocket 通常仍保持连接；soft watchdog 应把它视为活跃会话。
+const activeVncSockets = new Map<string, Set<Socket>>();
+
+function trackActiveVncSocket(instId: string, socket: Socket) {
+  let sockets = activeVncSockets.get(instId);
+  if (!sockets) {
+    sockets = new Set<Socket>();
+    activeVncSockets.set(instId, sockets);
+  }
+  if (sockets.has(socket)) return;
+  sockets.add(socket);
+  socket.once('close', () => {
+    const current = activeVncSockets.get(instId);
+    if (!current) return;
+    current.delete(socket);
+    if (current.size === 0) activeVncSockets.delete(instId);
+  });
+}
+
+function activeVncViewerCount(instId: string): number {
+  return activeVncSockets.get(instId)?.size ?? 0;
+}
+
 proxy.on('proxyReq', (proxyReq, req) => {
   const auth = (req as any)._wocAuth;
   if (auth) proxyReq.setHeader('authorization', auth);
@@ -1328,7 +1352,12 @@ proxy.on('proxyReqWs', (proxyReq, req) => {
   // 上游（实例 nginx → KasmVNC websockify）回 101 = ws 接收器接受了连接，桌面真正连上。
   // 卡死时这条不会出现（接收器停止 accept），即可定位"卡在面板→实例之间还是实例内部"。
   const instId = (req as any)._wocInstId;
-  if (instId) proxyReq.on('upgrade', () => appendInstanceLog(instId, '[vnc] 上游已接受(101) · 桌面连接建立'));
+  if (instId) {
+    proxyReq.on('upgrade', () => {
+      trackActiveVncSocket(instId, req.socket as Socket);
+      appendInstanceLog(instId, '[vnc] 上游已接受(101) · 桌面连接建立');
+    });
+  }
 });
 // 上游（面板→实例）套接字 TCP keepalive：客户端断网/切网（WiFi→4G、NAS 休眠）时 TCP 不会主动通知，
 // 半开死连接可挂数小时——对 KasmVNC 表现为"幽灵会话"占坑，与新连接并存是历史上 Xvnc 卡死的诱因之一。
@@ -1533,10 +1562,10 @@ function effectiveLimits(inst: Instance): { soft: number; hard: number } {
   };
 }
 
-// "当前有人在远程会话" 启发式判定：复用控制权心跳。前端在用户鼠标/键盘/滚轮交互时 2.5s 节流 beat，
-// 故 holder 在 TTL 内即视为"有人在主动操作"。只看屏（不交互）超过 TTL 后会被判为空闲——这是有意的，
-// 软自愈宁愿在"看似空闲"时短暂打扰，也不要拖到 hard 强制重启。
+// “当前有人在远程会话”同时看两类信号：VNC WebSocket 表示仍在观看，控制权心跳表示最近
+// 有键鼠操作。Chrome 后台标签页会停止交互心跳，但只要桌面连接仍在，就不能做 soft 重启。
 function hasActiveSession(id: string): boolean {
+  if (activeVncViewerCount(id) > 0) return true;
   const h = controlHolders.get(id);
   return !!h && Date.now() - h.at <= CONTROL_TTL;
 }
@@ -1577,8 +1606,9 @@ if (WATCHDOG_ENABLED) {
         if (mb > 0) {
           const { soft, hard } = effectiveLimits(inst);
           const active = hasActiveSession(inst.id);
+          const viewers = activeVncViewerCount(inst.id);
           if (hard > 0 && mb >= hard) {
-            await recover(inst, 'hard', `mem=${mb}MiB ≥ hard=${hard}MiB，强制重启（active=${active}）`);
+            await recover(inst, 'hard', `mem=${mb}MiB ≥ hard=${hard}MiB，强制重启（active=${active}, viewers=${viewers}）`);
             continue;
           }
           if (soft > 0 && mb >= soft && !active) {
@@ -1586,7 +1616,7 @@ if (WATCHDOG_ENABLED) {
             continue;
           }
           if (soft > 0 && mb >= soft && active) {
-            app.log.info(`[watchdog] ${inst.containerName} mem=${mb}MiB ≥ soft=${soft}MiB 但用户在使用，延后`);
+            app.log.info(`[watchdog] ${inst.containerName} mem=${mb}MiB ≥ soft=${soft}MiB 但用户在使用，延后（viewers=${viewers}）`);
           }
         }
         // 2) 响应性自愈：探测 VNC 是否还能提供页面；连续 N 次无响应 → 重启。


### PR DESCRIPTION
## What changed

- Track accepted VNC WebSocket connections per instance.
- Remove connections from the active-viewer set when the client socket closes.
- Treat either a connected VNC viewer or a recent control heartbeat as an active session.
- Include the viewer count in watchdog diagnostics.

## Why

The watchdog currently uses only the keyboard/mouse control heartbeat to decide whether an instance is in use. That heartbeat expires after ten seconds without input. When Chrome moves the desktop tab into the background, the VNC WebSocket can remain connected while no input events are generated, so the soft memory threshold incorrectly treats the instance as idle and rebuilds it.

This disconnects the desktop and restarts WeChat even though the user is still viewing the session in a background tab.

## Impact

Soft memory recovery is deferred while at least one accepted VNC connection is still open. Hard-limit recovery remains unchanged and can still restart the instance when required to protect the host.

The existing TCP keepalive handling ensures abandoned half-open connections are eventually removed instead of protecting an instance indefinitely.

## Validation

- Rebased onto the latest upstream `main` (`9ea0716`).
- `git diff --check` passes.
- Reproduced on a NAS before the fix: `mem=1524MiB >= soft=1500MiB` with no control heartbeat caused a soft watchdog rebuild after switching tabs.
- Built and deployed the same server-side change on the NAS.
- Temporarily lowered the soft threshold below current usage; the next watchdog pass logged `mem=397MiB >= soft=300MiB ... viewers=1` and deferred recovery.
- Restored the original per-instance thresholds and confirmed the WeChat container was not recreated.
